### PR TITLE
Allow users to configure parsers and detectors

### DIFF
--- a/tika-gui-app/src/main/java/module-info.java
+++ b/tika-gui-app/src/main/java/module-info.java
@@ -35,8 +35,8 @@ module org.tallison.tika.app.fx {
     opens org.tallison.tika.app.fx.ctx to com.fasterxml.jackson.databind, javafx.fxml;
     opens org.tallison.tika.app.fx.status to javafx.base;
     opens org.tallison.tika.app.fx.metadata to com.fasterxml.jackson.databind, javafx.fxml, javafx.base;
-    exports org.tallison.tika.app.fx.emitters;
     opens org.tallison.tika.app.fx.emitters to com.fasterxml.jackson.databind, javafx.fxml;
     opens org.tallison.tika.app.fx.config to com.fasterxml.jackson.databind, javafx.fxml;
     opens org.tallison.tika.app.fx.batch to com.fasterxml.jackson.databind, javafx.fxml;
+    opens org.tallison.tika.app.fx.advanced to com.fasterxml.jackson.databind, javafx.fxml;
 }

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/DetectorConfig.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/DetectorConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tallison.tika.app.fx.advanced;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class DetectorConfig {
+
+    private Path path;
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public Optional<Path> getPath() {
+        if (path == null) {
+            return Optional.empty();
+        }
+        return Optional.of(path);
+    }
+}

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/DetectorController.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/DetectorController.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tallison.tika.app.fx.advanced;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.Node;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.stage.FileChooser;
+import javafx.stage.Window;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.tallison.tika.app.fx.batch.BatchProcessConfig;
+import org.tallison.tika.app.fx.ctx.AppContext;
+
+public class DetectorController implements Initializable {
+
+    private static final AppContext APP_CONTEXT = AppContext.getInstance();
+    private static final Logger LOGGER = LogManager.getLogger(DetectorController.class);
+
+
+    @FXML
+    TextArea detectorConfigXML;
+
+    @FXML
+    TextField detectorConfigPath;
+
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+
+        if (APP_CONTEXT.getBatchProcessConfig().isEmpty()) {
+            return;
+        }
+        if (APP_CONTEXT.getBatchProcessConfig().get().getDetectorConfig().isEmpty()) {
+            return;
+        }
+        Optional<Path> path =
+                APP_CONTEXT.getBatchProcessConfig().get().getDetectorConfig().get().getPath();
+
+        if (path.isEmpty()) {
+            return;
+        }
+
+        if (!Files.isRegularFile(path.get())) {
+            LOGGER.warn("can't find detector config file");
+            return;
+        }
+        detectorConfigPath.setText(path.get().getFileName().toString());
+        loadConfig(path.get());
+    }
+
+    private void loadConfig(Path path) {
+        String xml = null;
+        try {
+            xml = FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            //TODO add dialog
+            LOGGER.warn("failed to load " + path);
+            return;
+        }
+        detectorConfigXML.setText(xml);
+        detectorConfigPath.setText(path.getFileName().toString());
+    }
+
+
+    public void openDetectorConfig(ActionEvent actionEvent) {
+        final Window parent = ((Node) actionEvent.getTarget()).getScene().getWindow();
+
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Open Detector Config");
+        BatchProcessConfig batchProcessConfig;
+        if (APP_CONTEXT.getBatchProcessConfig().isPresent()) {
+            batchProcessConfig = APP_CONTEXT.getBatchProcessConfig().get();
+        } else {
+            LOGGER.warn("batch process config is null?!");
+            actionEvent.consume();
+            return;
+        }
+        Optional<DetectorConfig> detectorConfigOptional = batchProcessConfig.getDetectorConfig();
+        if (detectorConfigOptional.isPresent()) {
+            Optional<Path> path = detectorConfigOptional.get().getPath();
+            if (path.isPresent()) {
+                File f = path.get().toFile();
+                fileChooser.setInitialDirectory(f.getParentFile());
+                fileChooser.setInitialFileName(f.getName());
+            }
+        }
+
+        File file = fileChooser.showOpenDialog(parent);
+        if (file == null) {
+            actionEvent.consume();
+            return;
+        }
+        DetectorConfig detectorConfig = detectorConfigOptional.orElse(new DetectorConfig());
+        detectorConfig.setPath(file.toPath());
+        batchProcessConfig.setDetectorConfig(detectorConfig);
+        loadConfig(file.toPath());
+        APP_CONTEXT.saveState();
+        actionEvent.consume();
+    }
+
+    public void saveDetectorConfig(ActionEvent actionEvent) {
+        final Window parent = ((Node) actionEvent.getTarget()).getScene().getWindow();
+
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Open Detector Config");
+        BatchProcessConfig batchProcessConfig;
+        if (APP_CONTEXT.getBatchProcessConfig().isPresent()) {
+            batchProcessConfig = APP_CONTEXT.getBatchProcessConfig().get();
+        } else {
+            LOGGER.warn("batch process config is null?!");
+            actionEvent.consume();
+            return;
+        }
+        Optional<DetectorConfig> detectorConfigOptional = batchProcessConfig.getDetectorConfig();
+        if (detectorConfigOptional.isPresent()) {
+            Optional<Path> path = detectorConfigOptional.get().getPath();
+            if (path.isPresent()) {
+                File f = path.get().toFile();
+                fileChooser.setInitialDirectory(f.getParentFile());
+                fileChooser.setInitialFileName(f.getName());
+            }
+        }
+
+        File file = fileChooser.showSaveDialog(parent);
+        if (file == null) {
+            actionEvent.consume();
+            return;
+        }
+
+        try {
+            FileUtils.write(file, detectorConfigXML.getText(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOGGER.warn("couldn't write file: " + file, e);
+            actionEvent.consume();
+            return;
+        }
+        DetectorConfig detectorConfig = detectorConfigOptional.orElse(new DetectorConfig());
+        detectorConfig.setPath(file.toPath());
+        batchProcessConfig.setDetectorConfig(detectorConfig);
+        APP_CONTEXT.saveState();
+        actionEvent.consume();
+    }
+
+    public void clearDetectorConfig(ActionEvent actionEvent) {
+        detectorConfigXML.setText("");
+        detectorConfigPath.setText("");
+        if (APP_CONTEXT.getBatchProcessConfig().isEmpty()) {
+            return;
+        }
+        if (APP_CONTEXT.getBatchProcessConfig().get().getDetectorConfig().isEmpty()) {
+            return;
+        }
+        //nullify path
+        APP_CONTEXT.getBatchProcessConfig().get().getDetectorConfig().get().setPath(null);
+    }
+}

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/ParserConfig.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/ParserConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tallison.tika.app.fx.advanced;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class ParserConfig {
+
+    private Path path;
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public Optional<Path> getPath() {
+        if (path == null) {
+            return Optional.empty();
+        }
+        return Optional.of(path);
+    }
+}

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/ParserController.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/advanced/ParserController.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tallison.tika.app.fx.advanced;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.Node;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.stage.FileChooser;
+import javafx.stage.Window;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.tallison.tika.app.fx.batch.BatchProcessConfig;
+import org.tallison.tika.app.fx.ctx.AppContext;
+
+public class ParserController implements Initializable {
+
+    private static final AppContext APP_CONTEXT = AppContext.getInstance();
+    private static final Logger LOGGER = LogManager.getLogger(ParserController.class);
+
+
+    @FXML
+    TextArea parserConfigXML;
+
+    @FXML
+    TextField parserConfigPath;
+
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+
+        if (APP_CONTEXT.getBatchProcessConfig().isEmpty()) {
+            return;
+        }
+        if (APP_CONTEXT.getBatchProcessConfig().get().getParserConfig().isEmpty()) {
+            return;
+        }
+        Optional<Path> path =
+                APP_CONTEXT.getBatchProcessConfig().get().getParserConfig().get().getPath();
+
+        if (path.isEmpty()) {
+            return;
+        }
+
+        if (!Files.isRegularFile(path.get())) {
+            LOGGER.warn("can't find parser config file");
+            return;
+        }
+        parserConfigPath.setText(path.get().getFileName().toString());
+        loadParserConfig(path.get());
+    }
+
+    private void loadParserConfig(Path path) {
+        String xml = null;
+        try {
+            xml = FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            //TODO add dialog
+            LOGGER.warn("failed to load " + path);
+            return;
+        }
+        parserConfigXML.setText(xml);
+        parserConfigPath.setText(path.getFileName().toString());
+    }
+
+
+    public void openParseConfig(ActionEvent actionEvent) {
+        final Window parent = ((Node) actionEvent.getTarget()).getScene().getWindow();
+
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Open Parser Config");
+        BatchProcessConfig batchProcessConfig;
+        if (APP_CONTEXT.getBatchProcessConfig().isPresent()) {
+            batchProcessConfig = APP_CONTEXT.getBatchProcessConfig().get();
+        } else {
+            LOGGER.warn("batch process config is null?!");
+            actionEvent.consume();
+            return;
+        }
+        Optional<ParserConfig> parserConfigOptional = batchProcessConfig.getParserConfig();
+        if (parserConfigOptional.isPresent()) {
+            Optional<Path> path = parserConfigOptional.get().getPath();
+            if (path.isPresent()) {
+                File f = path.get().toFile();
+                fileChooser.setInitialDirectory(f.getParentFile());
+                fileChooser.setInitialFileName(f.getName());
+            }
+        }
+
+        File file = fileChooser.showOpenDialog(parent);
+        if (file == null) {
+            actionEvent.consume();
+            return;
+        }
+        ParserConfig parserConfig = parserConfigOptional.orElse(new ParserConfig());
+        parserConfig.setPath(file.toPath());
+        batchProcessConfig.setParserConfig(parserConfig);
+        loadParserConfig(file.toPath());
+        APP_CONTEXT.saveState();
+        actionEvent.consume();
+    }
+
+    public void saveParseConfig(ActionEvent actionEvent) {
+        final Window parent = ((Node) actionEvent.getTarget()).getScene().getWindow();
+
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Open Parser Config");
+        BatchProcessConfig batchProcessConfig;
+        if (APP_CONTEXT.getBatchProcessConfig().isPresent()) {
+            batchProcessConfig = APP_CONTEXT.getBatchProcessConfig().get();
+        } else {
+            LOGGER.warn("batch process config is null?!");
+            actionEvent.consume();
+            return;
+        }
+        Optional<ParserConfig> parserConfigOptional = batchProcessConfig.getParserConfig();
+        if (parserConfigOptional.isPresent()) {
+            Optional<Path> path = parserConfigOptional.get().getPath();
+            if (path.isPresent()) {
+                File f = path.get().toFile();
+                fileChooser.setInitialDirectory(f.getParentFile());
+                fileChooser.setInitialFileName(f.getName());
+            }
+        }
+
+        File file = fileChooser.showSaveDialog(parent);
+        if (file == null) {
+            actionEvent.consume();
+            return;
+        }
+        //TODO: can we rely on showSaveDialog to warn the user about
+        //overwriting an existing file?
+        if (!Files.isDirectory(file.getParentFile().toPath())) {
+            try {
+                Files.createDirectories(file.getParentFile().toPath());
+            } catch (IOException e) {
+                LOGGER.warn("failed to create parent directory: " + file.getParent());
+                actionEvent.consume();
+                return;
+            }
+        }
+        try {
+            FileUtils.write(file, parserConfigXML.getText(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOGGER.warn("couldn't write file: " + file, e);
+            actionEvent.consume();
+            return;
+        }
+        ParserConfig parserConfig = parserConfigOptional.orElse(new ParserConfig());
+        parserConfig.setPath(file.toPath());
+        batchProcessConfig.setParserConfig(parserConfig);
+        APP_CONTEXT.saveState();
+
+        actionEvent.consume();
+    }
+
+    public void clearParseConfig(ActionEvent actionEvent) {
+        parserConfigXML.setText("");
+        parserConfigPath.setText("");
+        if (APP_CONTEXT.getBatchProcessConfig().isEmpty()) {
+            return;
+        }
+        if (APP_CONTEXT.getBatchProcessConfig().get().getParserConfig().isEmpty()) {
+            return;
+        }
+        //nullify path
+        APP_CONTEXT.getBatchProcessConfig().get().getParserConfig().get().setPath(null);
+    }
+
+    /*
+    boolean overWriteFileDialog(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return true;
+        }
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+        alert.setTitle("Parser Config");
+        alert.setContentText(
+                "The file already exists. Do you want to " + "overwrite the file or cancel?");
+        ButtonType overwrite = new ButtonType("Overwrite", ButtonBar.ButtonData.YES);
+        ButtonType cancelButton = new ButtonType("Cancel", ButtonBar.ButtonData.CANCEL_CLOSE);
+
+        alert.getButtonTypes().setAll(overwrite, cancelButton);
+        AtomicBoolean processAnyways = new AtomicBoolean(false);
+        alert.showAndWait().ifPresent(type -> {
+            if (type.getText().startsWith("Overwrite")) {
+                processAnyways.set(true);
+            } else if (type.getText().startsWith("Cancel")) {
+                processAnyways.set(false);
+            }
+        });
+        return processAnyways.get();
+    }*/
+
+}

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/batch/BatchProcessConfig.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/batch/BatchProcessConfig.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import org.tallison.tika.app.fx.advanced.DetectorConfig;
+import org.tallison.tika.app.fx.advanced.ParserConfig;
 import org.tallison.tika.app.fx.config.ConfigItem;
 import org.tallison.tika.app.fx.emitters.EmitterSpec;
 
@@ -36,6 +38,9 @@ public class BatchProcessConfig {
     private Optional<ConfigItem> pipesIterator = Optional.empty();
     private Optional<ConfigItem> fetcher = Optional.empty();
     private Optional<EmitterSpec> emitter = Optional.empty();
+
+    private ParserConfig parserConfig = null;
+    private DetectorConfig detectorConfig = null;
     private int outputSelectedTab = 0;
 
     private int inputSelectedTab = 0;
@@ -204,5 +209,27 @@ public class BatchProcessConfig {
 
     public void setWriteLimit(long writeLimit) {
         this.writeLimit = writeLimit;
+    }
+
+    public void setParserConfig(ParserConfig parserConfig) {
+        this.parserConfig = parserConfig;
+    }
+
+    public Optional<ParserConfig> getParserConfig() {
+        if (parserConfig == null) {
+            return Optional.empty();
+        }
+        return Optional.of(parserConfig);
+    }
+
+    public void setDetectorConfig(DetectorConfig detectorConfig) {
+        this.detectorConfig = detectorConfig;
+    }
+
+    public Optional<DetectorConfig> getDetectorConfig() {
+        if (detectorConfig == null) {
+            return Optional.empty();
+        }
+        return Optional.of(detectorConfig);
     }
 }

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/sax/DomWriter.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/sax/DomWriter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 public class DomWriter {
 
@@ -29,12 +30,18 @@ public class DomWriter {
         this.document = document;
     }
 
+    public void appendChild(Element rootElement, Element child) {
+        Node newNode = document.importNode(child, true);
+        rootElement.appendChild(newNode);
+    }
+
     public void appendMap(Element parent, String mappingsElementName, String mappingElementName,
                           Map<String, String> map, String... attrs) {
         Element mappings = createAndGetElement(parent, mappingsElementName, attrs);
         for (Map.Entry<String, String> e : map.entrySet()) {
             appendLeafElement(mappings, mappingElementName, "from", e.getKey(), "to", e.getValue());
         }
+
     }
 
     public void appendTextElement(Element parent, String itemName, String text, String... attrs) {

--- a/tika-gui-app/src/main/java/org/tallison/tika/app/fx/sax/XMLStringToDOM.java
+++ b/tika-gui-app/src/main/java/org/tallison/tika/app/fx/sax/XMLStringToDOM.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tallison.tika.app.fx.sax;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.utils.XMLReaderUtils;
+
+public class XMLStringToDOM {
+
+    public static void write(DomWriter writer, Element writerRoot, Optional<Path> path)
+            throws TikaException, IOException, SAXException {
+        Document document = XMLReaderUtils.buildDOM(path.get());
+        Element documentRoot = document.getDocumentElement();
+        writer.appendChild(writerRoot, documentRoot);
+    }
+}

--- a/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/batch-advanced-view.fxml
+++ b/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/batch-advanced-view.fxml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
-
 <?import java.lang.String?>
 <?import javafx.collections.FXCollections?>
 <?import javafx.scene.control.ComboBox?>
@@ -35,9 +33,14 @@
          <children>
             <TabPane layoutX="-1.0" layoutY="-1.0" prefHeight="375.0" prefWidth="600.0" tabClosingPolicy="UNAVAILABLE">
               <tabs>
-                <Tab closable="false" disable="true" text="Parsers">
+                <Tab closable="false" disable="false" text="Detectors">
                   <content>
-                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                    <fx:include fx:id="detector_config" source="detector-view.fxml"/>
+                  </content>
+                </Tab>
+                <Tab closable="false" disable="false" text="Parsers">
+                  <content>
+                    <fx:include fx:id="parser_config" source="parser-view.fxml"/>
                   </content>
                 </Tab>
                   <Tab closable="false" text="Parse Options">
@@ -55,7 +58,7 @@
                                 </items>
                               </ComboBox>
                               <Label layoutX="54.0" layoutY="110.0" prefHeight="21.0" prefWidth="121.0" text="Write Limit (bytes)" />
-                              <TextField fx:id="writeLimit" layoutX="188.0" layoutY="108.0" onAction="#setWriteLimit" alignment="CENTER_RIGHT" />
+                              <TextField fx:id="writeLimit" alignment="CENTER_RIGHT" layoutX="188.0" layoutY="108.0" onAction="#setWriteLimit" />
                            </children>
                         </AnchorPane>
                      </content>

--- a/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/detector-view.fxml
+++ b/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/detector-view.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="360.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.tallison.tika.app.fx.advanced.DetectorController">
+  <children>
+    <TextArea fx:id="detectorConfigXML" layoutX="58.0" layoutY="65.0" prefHeight="238.0" prefWidth="468.0" promptText="&lt;detectors&gt;&lt;/detectors&gt;" />
+    <Button fx:id="openDetectorConfig" layoutX="429.0" layoutY="32.0" mnemonicParsing="false" onAction="#openDetectorConfig" text="Open" />
+    <Label layoutX="453.0" layoutY="6.0" text="Parsers Config" />
+    <Button fx:id="saveDetectorConfig" layoutX="489.0" layoutY="32.0" mnemonicParsing="false" onAction="#saveDetectorConfig" text="Save" />
+    <Button fx:id="clearDetectorConfig" layoutX="545.0" layoutY="32.0" mnemonicParsing="false" onAction="#clearDetectorConfig" text="Clear" />
+    <TextField fx:id="parserConfigPath" layoutX="187.0" layoutY="305.0" prefHeight="26.0" prefWidth="264.0" />
+    <Label layoutX="58.0" layoutY="310.0" text="Selected Parser Config" />
+  </children>
+</AnchorPane>

--- a/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/parser-view.fxml
+++ b/tika-gui-app/src/main/resources/org/tallison/tika/app/fx/parser-view.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="360.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.tallison.tika.app.fx.advanced.ParserController">
+  <children>
+    <TextArea fx:id="parserConfigXML" layoutX="58.0" layoutY="65.0" prefHeight="238.0" prefWidth="468.0" promptText="&lt;parsers&gt;&lt;/parsers&gt;" />
+    <Button fx:id="openParseConfig" layoutX="429.0" layoutY="32.0" mnemonicParsing="false" onAction="#openParseConfig" text="Open" />
+    <Label layoutX="453.0" layoutY="6.0" text="Parsers Config" />
+    <Button fx:id="saveParseConfig" layoutX="489.0" layoutY="32.0" mnemonicParsing="false" onAction="#saveParseConfig" text="Save" />
+    <Button fx:id="clearParseConfig" layoutX="545.0" layoutY="32.0" mnemonicParsing="false" onAction="#clearParseConfig" text="Clear" />
+    <TextField fx:id="parserConfigPath" layoutX="187.0" layoutY="305.0" prefHeight="26.0" prefWidth="264.0" />
+    <Label layoutX="58.0" layoutY="310.0" text="Selected Parser Config" />
+  </children>
+</AnchorPane>


### PR DESCRIPTION
This is a first step relying on raw xml.  We don't verify the xml, etc.  This is just a preliminary attempt.  Next phase will read in parsers and getters/setters into an actual UI.